### PR TITLE
Npm Strategy

### DIFF
--- a/lib/strategies/bundler_strategy.rb
+++ b/lib/strategies/bundler_strategy.rb
@@ -1,19 +1,9 @@
-require 'inventory_printer'
+require "strategies/printed_strategy"
 
-class BundlerStrategy
-  attr_reader :repo, :strategy_name
-
-  def initialize(repo)
-    @strategy_name = :bundler
-    @repo = repo
+class BundlerStrategy < PrintedStrategy
+  def name
+    :bundler
   end
-
-  def perform
-    libraries = get_libraries
-    InventoryPrinter.new(repo, libraries, strategy_name)
-  end
-
-  private
 
   def get_libraries
     Dir.chdir(repo.file_location) do
@@ -33,6 +23,8 @@ class BundlerStrategy
         end
     end
   end
+
+  protected
 
   def get_license(gem_name)
     license_lines = `gem list #{gem_name} --details`

--- a/lib/strategies/npm_strategy.rb
+++ b/lib/strategies/npm_strategy.rb
@@ -1,22 +1,12 @@
-require 'inventory_printer'
+require 'strategies/printed_strategy'
 require 'json'
 
-class NpmStrategy
-  attr_reader :repo, :strategy_name
-
-  def initialize(repo)
-    @strategy_name = :npm
-    @repo = repo
+class NpmStrategy < PrintedStrategy
+  def name
+    :npm
   end
 
-  def perform
-    packages = get_packages
-    InventoryPrinter.new(repo, packages, :npm)
-  end
-
-  private
-
-  def get_packages
+  def get_libraries
     Dir.chdir(repo.file_location) do
       `npm install > /dev/null 2>&1`
 
@@ -32,6 +22,8 @@ class NpmStrategy
       end
     end
   end
+
+  protected
 
   def get_license(package_info)
     value = package_info['license'] || package_info['licenses']

--- a/lib/strategies/npm_strategy.rb
+++ b/lib/strategies/npm_strategy.rb
@@ -19,7 +19,7 @@ class NpmStrategy < PrintedStrategy
           "version" => package_info['version'],
           "license" => get_license(package_info)
         }
-      end
+      end.uniq
     end
   end
 

--- a/lib/strategies/npm_strategy.rb
+++ b/lib/strategies/npm_strategy.rb
@@ -11,8 +11,8 @@ class NpmStrategy < PrintedStrategy
       `npm install > /dev/null 2>&1`
 
       `npm list --parseable`.strip.split("\n").map do |package_path|
-        package_name = package_path.split("/").last
-        package_info = JSON.parse(`npm info #{package_name} --json`)
+        package_contents = File.read(package_path.strip + '/package.json')
+        package_info = JSON.parse(package_contents)
 
         {
           "name" => package_info['name'],

--- a/lib/strategies/npm_strategy.rb
+++ b/lib/strategies/npm_strategy.rb
@@ -1,0 +1,53 @@
+require 'inventory_printer'
+require 'json'
+
+class NpmStrategy
+  attr_reader :repo, :strategy_name
+
+  def initialize(repo)
+    @strategy_name = :npm
+    @repo = repo
+  end
+
+  def perform
+    packages = get_packages
+    InventoryPrinter.new(repo, packages, :npm)
+  end
+
+  private
+
+  def get_packages
+    Dir.chdir(repo.file_location) do
+      `npm install > /dev/null 2>&1`
+
+      `npm list --parseable`.strip.split("\n").map do |package_path|
+        package_name = package_path.split("/").last
+        package_info = JSON.parse(`npm info #{package_name} --json`)
+
+        {
+          "name" => package_info['name'],
+          "version" => package_info['version'],
+          "license" => get_license(package_info)
+        }
+      end
+    end
+  end
+
+  def get_license(package_info)
+    value = package_info['license'] || package_info['licenses']
+
+    if value.is_a?(Array)
+      value.map do |license|
+        if license.is_a?(Hash)
+          license['type']
+        else
+          license
+        end
+      end.join(', ')
+    elsif value.is_a?(Hash)
+      value['type']
+    else
+      value
+    end
+  end
+end

--- a/lib/strategies/printed_strategy.rb
+++ b/lib/strategies/printed_strategy.rb
@@ -1,0 +1,32 @@
+require "inventory_printer"
+
+class PrintedStrategy
+  attr_reader :libraries, :repo
+
+  def initialize(repo)
+    @repo = repo
+  end
+
+  def perform
+    @libraries = get_libraries
+    print_libraries
+  end
+
+  def get_libraries
+    raise "not implemented"
+  end
+
+  def print_libraries(libraries=[])
+    if libraries.nil? || libraries.empty?
+      libraries = self.libraries || []
+    end
+
+    InventoryPrinter.new(repo, libraries, name)
+  end
+
+  protected
+
+  def name
+    raise "not implemented"
+  end
+end

--- a/lib/strategy_factory.rb
+++ b/lib/strategy_factory.rb
@@ -1,8 +1,10 @@
 require 'strategies/bundler_strategy'
+require 'strategies/npm_strategy'
 
 class StrategyFactory
   FILES_FOR_STRATEGIES = {
-    'Gemfile' => BundlerStrategy
+    'Gemfile' => BundlerStrategy,
+    'package.json' => NpmStrategy
   }
 
   def self.get_strategies(repo)

--- a/spec/lib/strategies/bundler_strategy_spec.rb
+++ b/spec/lib/strategies/bundler_strategy_spec.rb
@@ -4,26 +4,21 @@ RSpec.describe BundlerStrategy do
   subject { described_class.new(repo) }
 
   let(:repo) { double('repo', file_location: '/tmp/oss-inventory') }
-  let(:libraries) do
-    [
-      {"name" => 'bundler', "version" => '1.13.1', "license" => 'MIT'},
-      {"name" => 'slop', "version" => '3.6.0', "license" => 'BSD'}
-    ]
-  end
 
-  describe '#get_license' do
-    context 'with no license' do
-      before do
-        allow(subject).to receive(:`).with('gem list bad_gem --details').and_return("")
-      end
-
-      it "returns NOT_FOUND" do
-        expect(subject.send(:get_license, 'bad_gem')).to eq('NOT_FOUND')
-      end
+  describe "#name" do
+    it "is defined" do
+      expect(subject.name).to eq(:bundler)
     end
   end
 
   describe '#get_libraries' do
+    let(:libraries) do
+      [
+        {"name" => 'bundler', "version" => '1.13.1', "license" => 'MIT'},
+        {"name" => 'slop', "version" => '3.6.0', "license" => 'BSD'}
+      ]
+    end
+
     context 'with no gems' do
       let(:no_gems_message) { "Could not locate Gemfile or .bundle/ directory\n" }
 
@@ -32,7 +27,7 @@ RSpec.describe BundlerStrategy do
       end
 
       it 'returns an empty array' do
-        expect(subject.send(:get_libraries)).to be_empty
+        expect(subject.get_libraries).to be_empty
       end
     end
 
@@ -82,16 +77,20 @@ SLOP
       end
 
       it "returns an object for each gem" do
-        expect(subject.send(:get_libraries)).to eq(libraries)
+        expect(subject.get_libraries).to eq(libraries)
       end
     end
   end
 
-  describe "#perform" do
-    it 'passes the retrieved library objects to InventoryPrinter' do
-      allow(subject).to receive(:get_libraries).and_return(libraries)
-      expect(InventoryPrinter).to receive(:new).with(repo, libraries, :bundler)
-      subject.perform
+  describe '#get_license' do
+    context 'with no license' do
+      before do
+        allow(subject).to receive(:`).with('gem list bad_gem --details').and_return("")
+      end
+
+      it "returns NOT_FOUND" do
+        expect(subject.send(:get_license, 'bad_gem')).to eq('NOT_FOUND')
+      end
     end
   end
 end

--- a/spec/lib/strategies/npm_strategy_spec.rb
+++ b/spec/lib/strategies/npm_strategy_spec.rb
@@ -109,6 +109,25 @@ RSpec.describe NpmStrategy do
       it "returns an object for each package" do
         expect(subject.get_libraries).to eq(packages)
       end
+
+      context "with duplicated packages" do
+        let(:npm_list_message) do
+          '
+          /tmp/oss-inventory/node_modules/run-command
+          /tmp/oss-inventory/node_modules/run-command/node_modules/custom-logger/node_modules/run-command
+          '
+        end
+
+        before do
+          allow(File).to receive(:read)
+            .with(/run-command\/package.json/)
+            .and_return(custom_logger_info_message)
+        end
+
+        it "does not duplicate output" do
+          expect(subject.get_libraries.count).to eq(1)
+        end
+      end
     end
   end
 

--- a/spec/lib/strategies/npm_strategy_spec.rb
+++ b/spec/lib/strategies/npm_strategy_spec.rb
@@ -1,0 +1,111 @@
+require 'strategies/npm_strategy'
+
+RSpec.describe NpmStrategy do
+  subject { described_class.new(repo) }
+
+  let(:repo) { double('repo', file_location: '/tmp/oss-inventory') }
+  let(:packages) do
+    [
+      {"name" => 'run-command', "version" => '0.0.1', "license" => 'MIT'},
+      {"name" => 'custom-logger', "version" => '1.8.3', "license" => 'BSD'}
+    ]
+  end
+  let(:npm_list_message) do
+    '
+    /tmp/oss-inventory/node_modules/run-command
+    /tmp/oss-inventory/node_modules/run-command/node_modules/custom-logger
+    '
+  end
+
+  before do
+    allow(subject).to receive(:`).with(/npm install/)
+    allow(subject).to receive(:`).with('npm list --parseable').and_return(npm_list_message)
+  end
+
+  describe '#perform' do
+    context 'with bad package.json' do
+      let(:npm_list_message) { "" }
+
+      it 'returns an empty array' do
+        expect(subject.send(:get_packages)).to be_empty
+      end
+    end
+
+    context 'with packages' do
+      let(:run_command_info_message) do
+        '{
+           "name": "run-command",
+           "description": "daisy chain running shell commands",
+           "dist-tags": {
+             "latest": "0.0.1"
+           },
+           "versions": [
+             "0.0.1"
+           ],
+           "maintainers": "itg <kevin@itsthatguy.com>",
+           "time": {
+             "modified": "2015-03-13T04:19:06.375Z",
+             "created": "2014-07-16T21:49:16.216Z",
+             "0.0.1": "2014-07-16T21:49:16.216Z"
+           },
+           "license": "MIT",
+           "readmeFilename": "README.md",
+           "homepage": "http://github.com/isthatguy/run-command",
+           "repository": {
+             "type": "git",
+             "url": "http://github.com/itsthatguy/run-command"
+           },
+           "author": "Kevin Altman <kevin@itsthatguy.com> (@itg)",
+           "bugs": {
+             "url": "https://github.com/itsthatguy/run-command/issues"
+           },
+           "version": "0.0.1",
+           "main": "index.js",
+           "scripts": {
+             "test": "echo \"Error: no test specified\" && exit 1"
+           },
+           "issues": {
+             "bugs": "http://github.com/itsthatguy/run-command/issues"
+           },
+           "dependencies": {
+             "custom-logger": "^0.2.1",
+             "win-spawn": "^2.0.0"
+           },
+           "gitHead": "453c45ae2ba45382fcf7d828a9ac14170988cdca",
+           "dist": {
+             "shasum": "08c84d3fcd53af76ded74b6a15e2b115b25621e8",
+             "tarball": "http://registry.npmjs.org/run-command/-/run-command-1.0.2.tgz"
+           },
+           "directories": {}
+         }'
+      end
+      let(:custom_logger_info_message) do
+        '{
+           "name": "custom-logger",
+           "version": "1.8.3",
+           "licenses": {
+             "type": "BSD",
+             "url": "http://www.opensource.org/licenses/BSD"
+           }
+         }'
+      end
+
+      before do
+        allow(subject).to receive(:`).with('npm info run-command --json').and_return(run_command_info_message)
+        allow(subject).to receive(:`).with('npm info custom-logger --json').and_return(custom_logger_info_message)
+      end
+
+      it "returns an object for each package" do
+        expect(subject.send(:get_packages)).to eq(packages)
+      end
+    end
+  end
+
+  describe "#perform" do
+    it 'passes the retrieved library objects to InventoryPrinter' do
+      allow(subject).to receive(:get_packages).and_return(packages)
+      expect(InventoryPrinter).to receive(:new).with(repo, packages, :npm)
+      subject.perform
+    end
+  end
+end

--- a/spec/lib/strategies/npm_strategy_spec.rb
+++ b/spec/lib/strategies/npm_strategy_spec.rb
@@ -98,8 +98,12 @@ RSpec.describe NpmStrategy do
       end
 
       before do
-        allow(subject).to receive(:`).with('npm info run-command --json').and_return(run_command_info_message)
-        allow(subject).to receive(:`).with('npm info custom-logger --json').and_return(custom_logger_info_message)
+        allow(File).to receive(:read)
+          .with('/tmp/oss-inventory/node_modules/run-command/package.json')
+          .and_return(run_command_info_message)
+        allow(File).to receive(:read)
+          .with('/tmp/oss-inventory/node_modules/run-command/node_modules/custom-logger/package.json')
+          .and_return(custom_logger_info_message)
       end
 
       it "returns an object for each package" do

--- a/spec/lib/strategies/printed_strategy_spec.rb
+++ b/spec/lib/strategies/printed_strategy_spec.rb
@@ -1,0 +1,45 @@
+require "strategies/printed_strategy"
+
+RSpec.describe PrintedStrategy do
+  subject { described_class.new(repo) }
+  let(:repo) { double("repo", file_location: "/tmp/oss-inventory") }
+
+  describe "#perform" do
+    context "when #get_libraries and #name are not implemented" do
+      it "raises an error" do
+        expect { subject.perform }.to raise_error("not implemented")
+      end
+    end
+
+    context "when #get_libraries and #name are implemented" do
+      before do
+        def subject.get_libraries; []; end
+        def subject.name; :strategy_name; end
+      end
+
+      it "delegates to InventoryPrinter" do
+        expect(InventoryPrinter).to receive(:new).with(repo, [], :strategy_name)
+        subject.perform
+      end
+    end
+  end
+
+  describe "#print_libraries" do
+    context "when #get_libraries and #name are implemented" do
+      before do
+        def subject.get_libraries; []; end
+        def subject.name; :strategy_name; end
+      end
+
+      it "delegates to InventoryPrinter" do
+        expect(InventoryPrinter).to receive(:new).with(repo, [], :strategy_name)
+        subject.print_libraries
+      end
+
+      it "prints overridden libraries" do
+        expect(InventoryPrinter).to receive(:new).with(repo, [{}], :strategy_name)
+        subject.print_libraries([{}])
+      end
+    end
+  end
+end

--- a/spec/lib/strategy_factory_spec.rb
+++ b/spec/lib/strategy_factory_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe StrategyFactory do
     let(:found_strategies) { described_class.get_strategies(repo) }
     let(:repo) { double('repo', file_location: '/tmp/oss-inventory') }
 
-    context 'when no representative files are found in the repo' do
-      before do
-        allow(File).to receive(:exist?).and_return(false)
-      end
+    before do
+      allow(File).to receive(:exist?).and_return(false)
+    end
 
+    context 'when no representative files are found in the repo' do
       it 'returns an empty array' do
         expect(found_strategies).to be_empty
       end
@@ -23,6 +23,17 @@ RSpec.describe StrategyFactory do
       it 'returns an instance of the BundlerStrategy' do
         expect(found_strategies.count).to eq(1)
         expect(found_strategies.first).to be_a(BundlerStrategy)
+      end
+    end
+
+    context 'when a package.json exists' do
+      before do
+        allow(File).to receive(:exist?).with('package.json').and_return(true)
+      end
+
+      it 'returns an instance of the NpmStrategy' do
+        expect(found_strategies.count).to eq(1)
+        expect(found_strategies.first).to be_a(NpmStrategy)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,7 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  config.filter_run_when_matching :focus
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
* Adds a Strategy for parsing libraries from an NPM-managed project
* Adds parent class for existing Strategies: `ParentStrategy`
  * Refactors Strategies' API and tests accordingly
* tests, tests, tests

Addresses #2.