### PR TITLE
Recognize different bundler environments

### DIFF
--- a/lib/strategies/bundler_strategy.rb
+++ b/lib/strategies/bundler_strategy.rb
@@ -7,20 +7,24 @@ class BundlerStrategy < PrintedStrategy
 
   def get_libraries
     Dir.chdir(repo.file_location) do
-      `bundle show`
-        .split("\n")
-        .select { |line| line.strip.start_with?('*') }
-        .map do |line|
-          _, gem_name, version = line.split
-          version = version.gsub(/[()]/, '')
-          license = get_license(gem_name)
+      Bundler.with_clean_env do
+        `bundle install`
 
-          {
-            "name" => gem_name,
-            "version" => version,
-            "license" => license
-          }
-        end
+        `bundle show`
+          .split("\n")
+          .select { |line| line.strip.start_with?('*') }
+          .map do |line|
+            _, gem_name, version = line.split
+            version = version.gsub(/[()]/, '')
+            license = get_license(gem_name)
+
+            {
+              "name" => gem_name,
+              "version" => version,
+              "license" => license
+            }
+          end
+      end
     end
   end
 

--- a/spec/lib/strategies/bundler_strategy_spec.rb
+++ b/spec/lib/strategies/bundler_strategy_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe BundlerStrategy do
       ]
     end
 
+    before do
+      allow(subject).to receive(:`).with('bundle install')
+    end
+
     context 'with no gems' do
       let(:no_gems_message) { "Could not locate Gemfile or .bundle/ directory\n" }
 


### PR DESCRIPTION
Fixes #6 

When running bundler from Ruby, by default it will inherit the current
bundler environment. For oss-inventory, that isn't what we want.

We need to do two things here:

1. Tell bundler to refresh its environment by wrapping our system calls
in a `Bundler.with_clean_env` block.
2. Ensure that we have local copies of the project's gems (required by
`bundle show`) by doing a `bundle install`.

See
https://stackoverflow.com/questions/25615289/run-bundle-system-command-in-subfolder
for more details on the issue that this addresses.