### PR TITLE
Update CircleCI config to 2.0 style

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.3
+    steps:
+      - checkout
+      - run:
+          name: Run RSpec tests
+          command: |
+            gem install bundler
+            bundle
+            rspec

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 Gemfile.lock
-config.yml
+./config.yml


### PR DESCRIPTION
As per https://circleci.com/docs/2.0/migrating-from-1-2/, CircleCI v1.0 is shutting down later this year, so I want to get us all up to 2.0 before then.

It didn't look like the previous CircleCI config was doing anything, so I just went with a super basic "run the tests" one here to satisfy the new requirements.